### PR TITLE
Agregando el archivo requirements.txt 

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Además, tiene una base de datos local con las definiciones de las 1000 palabras
 # Empezar a Usar
 
 ## Requisitos
-Aparte de requerir ulauncher, RAE DLE requiere
+Aparte de requerir ulauncher, RAE DLE requiere de los siguientes paquetes de python
 *	BeautifulSoup4
 *	Requests
 
@@ -107,6 +107,8 @@ Hay dos formas de instalar la extensión.
 	```
 	cd ~/.local/share/ulauncher/extensions
 	git clone https://github.com/sebastian-correa/ulauncher-rae-dle.git
+	cd ulauncher-rae-dle
+  	pip3 install -r requirements.txt
 	```
 3.	Abrir ulauncher.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+beautifulsoup4
+requests


### PR DESCRIPTION
Creo que es necesario colocar este archivo para especificar las dependencias, aunque ya esta especificado en el README.md creo que seria mas facil realizar `pip3 -r requirements.txt` para instalar las dependencias